### PR TITLE
Migrate to raylib 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ build/
 package64/
 .cache/
 
+# Zig build system
+zig-out/
+.zig-cache/
+
 # MacOS Cache
 .DS_Store
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "raylib"]
+	path = raylib
+	url = https://github.com/raysan5/raylib.git

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-xmake build && xmake install -o ./package64/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const raylib = b.dependency("raylib", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "rayplat",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.addCSourceFiles(.{ .files = &all_sources });
+
+    exe.installLibraryHeaders(raylib.artifact("raylib"));
+    exe.linkLibrary(raylib.artifact("raylib"));
+    b.installArtifact(exe);
+}
+
+const all_sources = [_][]const u8 {
+    "src/main.cpp",
+    "src/raymain.c",
+};

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = "rayplat",
+    .version = "0.0.0",
+    .minimum_zig_version = "0.13.0",
+    .dependencies = .{
+        .raylib = .{
+            .path = "./raylib",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}

--- a/prepare-raylib.cmd
+++ b/prepare-raylib.cmd
@@ -1,0 +1,5 @@
+@echo off
+git submodule update --init --recursive
+pushd raylib
+git checkout 5.5
+popd

--- a/prepare-raylib.sh
+++ b/prepare-raylib.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+git submodule update --init --recursive
+pushd raylib
+git checkout 5.5
+popd

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,7 +1,7 @@
 add_rules("mode.debug", "mode.release")
 set_languages("c99", "c++20")
 add_repositories("local-repo deps")
-add_requires("raylib-minimal 5.0", { alias = "raylib", system = false })
+add_requires("raylib-minimal 5.5", { alias = "raylib", system = false })
 add_requireconfs("raylib-minimal.libglvnd", { system = false })
 
 function copy_executable_to_lib(target)


### PR DESCRIPTION
This change adds two changes:

1. Use zig as build system. Raylib has used Zig. It offers a cross-platform build system running on a single machine.
2. Upgrade to raylib 5.5. It adds support for retro platform.

The xmake script is kept, in order to provide compile_commands.json. I need it for future iOS/Android build support until I figure out how to do it with zig.